### PR TITLE
Astroctx v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 ## [Unreleased][unreleased]
 
+## [1.1.0][] - 2023-10-01
+
+### Major updates
+
+- Removed astro syntax with type option, now only supports common js syntax.
+- Context updates
+  1. Renamed to sandbox, example: <code>Astroctx.sandbox</code>
+  2. To create new contexts you should use <code>Astroctx.sandbox({ myCtxVariable: 'test' })</code>
+  3. All presets still should be working properly with <code>Astroctx.sandbox[preset-key]</code>
+- Reader updates
+  1. Joined with require, now require works as reader, examples:
+     ```js
+     Astroctx.require('./my-path/to/script.js');
+     Astroctx.require.script('./my-path/to/script.js');
+     Astroctx.require.dir('./my-path/to');
+     ```
+  2. New access controll feature, see access updates
+- Access updates, now this option work for both sandbox and reader, you need to provide function
+  ```js
+  const option = { access: pathOrModule => pathOrModule === 'fs' || pathOrModule.endsWith('.js') };
+  Astroctx.execute('module.exports = require("fs")');
+  Astroctx.read('./path/to/script.js');
+  // But you still can controll them by each own function
+  const option = {
+    access: {
+      internal: path => true, // Reader controll
+      sandbox: module => {}, // Sandbox require controll
+    },
+  };
+  ```
+  > Sandbox function can return object or boolean value, in case of object it will be used as stub
+  > content
+
+### Minor updates
+
+- Created new tests, new tests coverage ~85%
+- NPM Isolation fix, now it should work properly
+
+  ```js
+  const script = Astroctx.execute(`module.exports = require('chalk')`, {
+    access: { sandbox: () => true },
+    npmIsolation: true,
+    ctx: sandbox.NODE,
+  }); // Output: Chalk function
+  ```
+
 ## [1.0.0][] - 2023-08-26
 
 - Transferred from leadfisher
@@ -13,5 +59,6 @@
 - Quality of life improvements
 - Massive README update, documentation improvement
 
-[unreleased]: https://github.com/astrohelm/astroctx/compare/v1.0.0...HEAD
+[unreleased]: https://github.com/astrohelm/astroctx/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/astrohelm/astroctx/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/astrohelm/astroctx/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Astroctx - VM Container for Javascript</h1>
+<h1 align="center">Astroctx - VM Container for Commonjs</h1>
 
 **Why should i use it ?** How often do you see libraries which mutates global variables Or how often
 do you check libraries actins ? Astroctx provides script isolation in custom contexts to solve this
@@ -9,10 +9,7 @@ issues. And yes, this library written to prevent unexpected behavior.
 
 <h2 align="center">Installation</h2>
 
-_Warning !_ Requirements:
-
-- Only for commonjs
-- If you use reader, you should use .js or .cjs or no extensions for your files
+_Warning !_ Require: commonjs syntax
 
 ```bash
 npm i astroctx --save
@@ -27,7 +24,7 @@ npm i astroctx --save
   ```javascript
   // index.js
   const Astroctx = require('astroctx');
-  Astroctx.read('./routes', { access: { fs: false, npmIsolation: true } }); // Will throw error that fs doesn't allowed
+  const routes = Astroctx.read('./routes', { access: { sandbox: module => module !== 'fs' } }); // Will throw error that fs doesn't allowed
   ```
 
   ```javascript
@@ -66,119 +63,39 @@ npm i astroctx --save
   console('Here it works fine');
   ```
 
-<h2 align="center">Script syntax</h2>
+<h2 align="center">Details</h2>
 
-- By default, script execution will return result of the last expression.
+### Access controll
 
-  This behavior works under option <code>{ type: 'js' }</code> only
+You may control access to some modules or paths of your application
 
-  You can use it for configs, network packets, serialization format, etc. Function expression can be
-  used as api endpoint, domain logic, etc. But you also can use any type of javascript expression
-  inside the script.
-
-  ```javascript
-  const Astroctx = require('astroctx');
-  console.log(new Astroctx(`({ field: 'value' });`).execute()); // Output: { field: 'value' }
-  console.log(Astroctx.execute(`(a, b) => a + b;`)(2 + 2)); // Output: 4
-  Astroctx.execute(`async (a, b) => a + b;`)(2 + 2).then(console.log); // Output: 4
-  ```
-
-- Or if you want to use module syntax, you should add <code>{ type: 'cjs' }</code> option.
-
-  Or just name the file with <code>.cjs</code> extension if you use reader.
-
-  ```javascript
-  const Astroctx = require('astroctx');
-  console.log(new Astroctx(`module.exports = { field: 'value' };`).execute()); // Output: { field: 'value' }
-  console.log(Astroctx.execute(`module.exports = (a, b) => a + b;`)(2 + 2)); // Output: 4
-  Astroctx.execute(`module.exports = async (a, b) => a + b;`)(2 + 2).then(console.log); // Output: 4
-  ```
-
-> _Warning !_ Extensions will replace your provided type option, if you use reader. For example:
->
-> - astro.js -> js
-> - astro.cjs & { type: 'js'} -> cjs
-> - astro.js & { type: 'cjs' } -> js
-> - astro & { type: 'cjs' } -> js
-
-<h2 align="center">More about API</h2>
-
-### Module API
-
-Module provides next work schema
-
-```typescript
-import { Context, Script, ScriptOptions, BaseOptions } from 'node:vm';
-import { RunningCodeOptions, CreateContextOptions } from 'node:vm';
-
-type MODULE_TYPE = 'cjs' | 'js';
-type TMap<value> = { [key: string]: value };
-
-export const COMMON_CTX: Context;
-export const MODULE_TYPES: MODULE_TYPE[];
-
-export interface TOptions extends BaseOptions {
-  dir?: string;
-  filename?: string;
-  type?: MODULE_TYPE;
-  access?: TMap<boolean | object>;
-  ctx?: Context;
-  run?: RunningCodeOptions;
-  script?: ScriptOptions;
-  npmIsolation?: boolean;
-}
-
-interface TOptionsReader extends Omit<TOptions, 'type'> {
-  prepare?: boolean;
-}
-
-type TRead = {
-  (path: string, options?: TOptionsReader): Promise<Script>;
-  script: (path: string, options?: TOptionsReader) => Promise<Script>;
-  dir: (path: string, options?: TOptionsReader, deep?: boolean) => Promise<TMap<unknown>>;
+```js
+const option = { access: pathOrModule => pathOrModule === 'fs' || pathOrModule.endsWith('.js') };
+Astroctx.execute('module.exports = require("fs")');
+Astroctx.read('./path/to/script.js');
+// Or
+const option2 = {
+  access: {
+    internal: path => true, // Reader controll
+    sandbox: module => {}, // Sandbox require controll
+  },
 };
-
-type TCtx = {
-  OPTIONS: CreateContextOptions;
-  EMPTY: Context;
-  COMMON: Context;
-  NODE: Context;
-  create: (ctx?: Context | Object, preventEscape?: boolean) => Context;
-};
-
-export default class Astroctx {
-  name: string;
-  dir: string;
-  type: MODULE_TYPE;
-
-  static CTX: TCtx;
-  static read: TRead;
-  static prepare: (src: string, options?: TOptions) => Script;
-  static execute: (src: string, options?: TOptions) => unknown;
-  static require: (path: string, options?: TOptionsReader) => Promise<Script>;
-
-  constructor(src: string, options?: TOptions): Script;
-  execute: (ctx?: Context) => unknown;
-}
 ```
 
-#### About possible options
+> If access doesn't provided sandbox submodules would'nt be accessible and reader will read all
+> files in directed repository
 
-- **type**: <code>_js_</code> Script execution returns last expression <code>_cjs_</code> Script
-  execution returns all that module.exports includes. If you use read API, types will be placed
-  automatically, based on your files.
-- **filename**: Stands for the name of the module, by default it's empty string
-- **dir**: Stands for the name of the module directory, by default <code>process.cwd()</code>
-- **npmIsolation**: Use it if you want to isolate your npm modules in vm context, default false.
-- **ctx**: Script execution closured by context, by default it's clear that is why you can't use
-  even <code>setTimeout</code> or <code>setInterval</code>, work only with result of
-  <code>CTX.create</code> or <code>CTX.EMPTY | CTX.COMMON | CTX.NODE</code>.
-- **access**: Contains _absolute paths_ to nested modules or name of _npm/origin_ libraries as keys,
-  and stub-content or boolean as values, _by default_ you can't require nested modules.
-- **prepare**: Works only with read API, functions, where this option provided, will return
-  intermediate object and you will be able to finish execution later. Script has alternative to this
-  option - <code>prepare method</code>.
-- **script** & **run** This options allow you to configure VM.Script initialization & execution.
+### Common js
+
+Astroctx supports only commonjs syntax from <code>v1.1.0</code> That's because currently node.vm
+doesn't support ecmascript syntax
+
+```javascript
+const Astroctx = require('astroctx');
+console.log(new Astroctx(`module.exports = { field: 'value' };`).execute()); // Output: { field: 'value' }
+console.log(Astroctx.execute(`module.exports = (a, b) => a + b;`)(2 + 2)); // Output: 4
+Astroctx.execute(`module.exports = async (a, b) => a + b;`)(2 + 2).then(console.log); // Output: 4
+```
 
 ### Context API
 
@@ -187,19 +104,30 @@ You can create custom context or use default presets with context api.
 ```typescript
 import  { Context, CreateContextOptions } from 'node:vm';
 {
-  OPTS: CreateContextOptions,
+  OPTIONS: CreateContextOptions,
   EMPTY: Context, // Result of CTX.create(Object.freeze({}))
   COMMON: Context, // Frozen nodejs internal api
   NODE: Context, // Frozen nodejs internal api & global variables
-  create: (ctx: object, preventEscape: boolean) => Context
+  (ctx: object, preventEscape: boolean): Context
 }
 ```
 
 ```javascript
-const { CTX, execute } = require('astroctx');
-const custom = CTX.createContext({ console });
+const { sandbox, execute } = require('astroctx');
+const custom = sandbox({ console });
 execute(`console.log(123);`, { ctx: custom }); // Output: 123
 execute(`console.log(123);`); // No output, because different stdout stream
+```
+
+This will allow you to provide your custom variables to the context without requiring any module and
+with link safety. Also it can allow you to change program behavior with somthing like:
+
+```js
+const ctx = Astroctx.sandbox({ a: 1000, b: 10 });
+const prepared = Astroctx.prepare(`module.exports = a - b`, { ctx });
+prepared.execute(); // Output: 990
+prepared.execute({ ...ctx, a: 0 }); // Output: -10
+prepared.execute({ ...ctx, b: 7 }); // Output: 993
 ```
 
 ### Reader API
@@ -208,23 +136,27 @@ Reader allow you to run scripts from files
 
 - <code>read</code> Allow you to read files or directories
 
-  You should use specific methods to have better performance.
-
-  - Option <code>prepare</code> allow you to run script later
-  - Option <code>deep</code> allow you to read scripts from nested directories
+  You should use specific methods to have better performance. Option <code>prepare</code> allow you
+  to run script later
 
   ```javascript
-  const { read } = require('astroctx');
+  const { require: read } = require('astroctx');
   read('./path/to/script.js').then(console.log); // Output: result of script execution
   read('./path/to').then(console.log); // Output: { script: any }
   read('./path/to', { prepare: true }).then(console.log); // Output: { script: Script {} }
-  read('./path/to', { deep: true }).then(console.log); // Output: { script: any, deep: { script: any } }
+  ```
+
+  By default reader works with nested directories, to disable this behavior you can do:
+
+  ```js
+  const { require: read } = require('astroctx');
+  read('./path/to', {}, false);
   ```
 
 - <code>read.script</code> Allow you to read single file
 
   ```javascript
-  const { read } = require('astroctx');
+  const { require: read } = require('astroctx');
   read.script('./path/to/script.js').then(console.log); // Output: result of script execution
   read.script('./path/to/script.js', { prepare: true }).then(console.log); // Output: Script {}
   ```
@@ -232,22 +164,21 @@ Reader allow you to run scripts from files
 - <code>read.dir</code> Allow you to read a directory
 
   ```javascript
-  const { read } = require('astroctx');
-  read.script('./path/to').then(console.log); // Output: { script: any }
+  const { require: read } = require('astroctx');
+  read.script('./path/to').then(console.log); // Output: { script: any, deep: { script: any } }
   read.script('./path/to', { prepare: true }).then(console.log); Output: { script: Script {} }
-  read.script('./path/to', { nested: true }).then(console.log); // Output: { script: any, deep: { script: any } }
+  read.script('./path/to', {}, false).then(console.log); // Output: { script: any }
   ```
 
 <h2>Other useful information</h2>
 
 - **Script from string** You can run any script from string, just like eval, but in custom VM
-  container.But you shouldn't use it for unknown script evaluation, it may create security issues.
+  container. But you shouldn't use it for unknown script evaluation, it may create security issues.
 
   ```js
   const Astroctx = require('astroctx');
-  console.log(new Astroctx(`({ field: 'value' });`).execute()); // Output: { field: 'value' }
-  console.log(Astroctx.execute(`(a, b) => a + b;`)(2 + 2)); // Output: 4
-  Astroctx.execute(`async (a, b) => a + b;`)(2 + 2).then(console.log); // Output: 4
+  console.log(Astroctx.execute(`module.exports = (a, b) => a + b;`)(2 + 2)); // Output: 4
+  Astroctx.execute(`module.exports = async (a, b) => a + b;`)(2 + 2).then(console.log); // Output: 4
   ```
 
 - **Library substitution** For example it can be use to provide custom fs module, with your strict
@@ -268,18 +199,29 @@ Reader allow you to run scripts from files
     `;
     const ms = exec(src, {
       access: {
-        fs: {
-          readFile(filename, callback) {
-            callback(null, 'stub-content');
+        sandbox: module => ({
+          fs: {
+            readFile: (filename, callback) => callback(null, 'stub-content');
           },
-        },
+        })[module];
       },
-      type: 'cjs',
     });
     const res = await ms.useStub();
     console.log(res);
   })(); // Output: stub-content
   ```
+
+### Script Options
+
+- **filename**: Stands for the name of the module, by default it's empty string
+- **dir**: Stands for the name of the module directory, by default <code>process.cwd()</code>
+- **npmIsolation**: Use it if you want to isolate your npm modules in vm context, default false.
+- **ctx**: See Context API
+- **access**: See Access API
+- **prepare**: Works only with read API. Functions, where this option provided, will return
+  intermediate object and you will be able to finish execution later. Script has alternative to this
+  option - <code>prepare method</code>.
+- **script** & **run** This options allow you to configure VM.Script initialization & execution.
 
 <h2 align="center">Copyright & contributors</h2>
 

--- a/index.js
+++ b/index.js
@@ -1,45 +1,4 @@
 'use strict';
 
-const { basename, extname, join, dirname } = require('node:path');
-const { readFile, readdir, stat } = require('node:fs').promises;
-const { CTX, WRAPPERS } = require('./lib/default');
-const { scriptType } = require('./lib/utils');
-const MODULE_TYPES = Object.keys(WRAPPERS);
-const Script = require('./lib/script');
-
-const read = async (path, options = {}, deep = true) => {
-  const isDir = (await stat(path)).isDirectory();
-  const result = await (isDir ? read.dir(path, options, deep) : read.script(path, options));
-  return result;
-};
-
-read.dir = async (dir, options = {}, deep = true) => {
-  const files = await readdir(dir, { withFileTypes: true });
-  const scripts = {};
-
-  const loader = async (file, path) => {
-    const [reader, ext] = [file.isFile() ? read.script : read.dir, extname(file.name)];
-    const name = basename(file.name, MODULE_TYPES.includes(ext.slice(1)) ? ext : '');
-    scripts[name] = await reader(path, options);
-  };
-
-  const promises = files.reduce((acc, file) => {
-    if (!file.isDirectory() && !MODULE_TYPES.includes(extname(file.name).slice(1))) return acc;
-    if (file.isDirectory() && !deep) return acc;
-    return acc.push(loader(file, join(dir, file.name))), acc;
-  }, []);
-
-  await Promise.all(promises);
-  return scripts;
-};
-
-read.script = async (path, options = {}) => {
-  const src = await readFile(path, 'utf8');
-  if (!src) throw new SyntaxError(`File ${path} is empty`);
-  const [filename, dir] = [basename(path), dirname(path)];
-  const runner = options.prepare ? Script.prepare : Script.execute;
-  return runner(src, { ...options, filename, dir, type: scriptType(filename), prepare: false });
-};
-
-[Script.read, Script.CTX, Script.require] = [read, CTX, read.script];
-module.exports = Script;
+module.exports = require('./lib/script');
+module.exports.require = require('./lib/reader');

--- a/lib/ctx.js
+++ b/lib/ctx.js
@@ -2,11 +2,6 @@
 
 const { createContext } = require('node:vm');
 
-const WRAPPERS = {
-  js: src => `{\n${src}\n}`,
-  cjs: src => `(({exports, require, module, __filename, __dirname}) => {\n${src}\n});`,
-};
-
 const NODE = { global, console, process };
 const TIME = { setTimeout, setImmediate, setInterval, clearTimeout, clearImmediate, clearInterval };
 const BUFF = { Buffer, TextDecoder, TextEncoder };
@@ -15,19 +10,13 @@ const EVENT = { Event, EventTarget, queueMicrotask };
 const MESSAGE = { MessageChannel, MessageEvent, MessagePort };
 const DEFAULT = { AbortController, ...EVENT, ...BUFF, ...URI, ...TIME, ...MESSAGE };
 
-const RUN_OPTS = { timeout: 1000 };
 const CTX_OPTS = { codeGeneration: { strings: false, wasm: false } };
 
 const CTX = {
   OPTIONS: CTX_OPTS,
   EMPTY: createContext(Object.freeze({}), CTX_OPTS),
-  COMMON: createContext(Object.freeze({ ...DEFAULT })),
-  NODE: createContext(Object.freeze({ ...DEFAULT, ...NODE })),
+  COMMON: createContext(Object.freeze({ ...DEFAULT }), CTX_OPTS),
+  NODE: createContext(Object.freeze({ ...DEFAULT, ...NODE }), CTX_OPTS),
 };
 
-CTX.create = (ctx, mode = false) => {
-  if (!ctx) return CTX.EMPTY;
-  return createContext(ctx, { ...CTX.OPTIONS, preventEscape: mode ? 'afterEvaluate' : '' });
-};
-
-module.exports = { CTX, WRAPPERS, RUN_OPTS };
+module.exports = CTX;

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const [Script, { checkAccess }] = [require('./script'), require('./utils')];
+const { basename, extname, join, dirname } = require('node:path');
+const { readFile, readdir, stat } = require('node:fs').promises;
+
+const read = async (path, options = {}, deep = true) => {
+  const isDir = (await stat(path)).isDirectory();
+  const result = await (isDir ? read.dir(path, options, deep) : read.script(path, options));
+  return result;
+};
+
+read.dir = async (dir, options = {}, deep = true) => {
+  const files = await readdir(dir, { withFileTypes: true });
+  const scripts = {};
+
+  const loader = async (file, path) => {
+    const [reader, ext] = [file.isFile() ? read.script : read.dir, extname(file.name)];
+    const name = basename(file.name, ext.match(/^\.[cme]?js$/) ? ext : '');
+    scripts[name] = await reader(path, options);
+  };
+
+  const promises = files.reduce((acc, file) => {
+    const path = join(dir, file.name);
+    if (!checkAccess(path, options.access, 'internal')) return acc;
+    if (file.isDirectory() && !deep) return acc;
+    return acc.push(loader(file, path)), acc;
+  }, []);
+
+  await Promise.all(promises);
+  return scripts;
+};
+
+read.script = async (path, options = {}) => {
+  const src = await readFile(path, 'utf8');
+  if (!src) throw new SyntaxError(`File ${path} is empty`);
+  const [filename, dir] = [basename(path), dirname(path)];
+  const runner = options.prepare ? Script.prepare : Script.execute;
+  return runner(src, { ...options, filename, dir, prepare: false });
+};
+
+module.exports = read;

--- a/lib/require.js
+++ b/lib/require.js
@@ -1,8 +1,8 @@
 'use strict';
 
+const { basename, dirname, resolve } = require('node:path');
 const { readFileSync } = require('node:fs');
 const { checkAccess } = require('./utils');
-const { basename, dirname, resolve } = require('node:path');
 const internalRequire = require;
 class VMError extends Error {}
 
@@ -12,7 +12,7 @@ module.exports = (options, exec) => {
   return module => {
     const npm = !module.includes('.');
     const name = !npm ? resolve(dir, module) : module;
-    const lib = checkAccess(name, access);
+    const lib = checkAccess(name, access, 'sandbox');
 
     if (lib instanceof Object) return lib;
     if (!lib) throw new VMError(`Access denied '${module}'`);
@@ -20,6 +20,7 @@ module.exports = (options, exec) => {
       const absolute = internalRequire.resolve(name);
       if (npm && absolute === name) return internalRequire(name); //? Integrated nodejs API
       if (npm && !npmIsolation) return internalRequire(absolute); //?  VM uncover Npm packages
+      if (absolute.endsWith('.json')) return internalRequire(absolute); //? JSON modules
       const [filename, dir, type] = [basename(absolute), dirname(absolute), undefined];
       const exports = exec(readFileSync(absolute, 'utf8'), { ...options, filename, dir, type });
       return exports;

--- a/lib/script.js
+++ b/lib/script.js
@@ -1,26 +1,22 @@
 'use strict';
 
-const { scriptType, wrapper: wrap, cjs } = require('./utils');
-const { CTX, RUN_OPTS } = require('./default');
-const createRequire = require('./require');
-const { Script: VM } = require('node:vm');
+const [createRequire, { wrap, exec }] = [require('./require'), require('./utils')];
+const { Script: VM, isContext, createContext } = require('node:vm');
 
 const Script = function (src, opts = {}) {
-  if (!this) return new Script(src, opts);
-  const { script = {}, run = {}, ctx = {}, filename = 'Astro', dir = process.cwd(), type } = opts;
+  if (!new.target) return new Script(src, opts);
+  const { script = {}, run = {}, ctx = {}, filename = 'Astro', dir = process.cwd() } = opts;
+  const lineOffset = src.includes('use strict') ? -1 : -2;
+  const machine = new VM(wrap(src), { filename, lineOffset, ...script });
+  const require = createRequire({ ...opts, dir }, Script.execute);
+  const context = Script.sandbox(Object.freeze(ctx));
 
   [this.name, this.dir] = [filename, dir];
-  this.type = type ?? (filename && filename !== 'Astro' ? scriptType(this.name) : 'js');
-  const isJS = this.type === 'js';
-
-  const require = createRequire({ ...opts, dir }, Script.execute);
-  const baseCTX = { require, __filename: this.name, __dirname: this.dir };
-  const context = CTX.create(Object.freeze(isJS ? { ...ctx, ...baseCTX } : ctx));
-  const machine = new VM(wrap(src, this.type), { filename, lineOffset: -1 - isJS, ...script });
-
   this.execute = (ctx = context) => {
-    const exports = machine.runInContext(ctx, { ...RUN_OPTS, ...run });
-    return isJS ? exports : cjs(exports, baseCTX);
+    if (!isContext(ctx)) ctx = Script.sandbox(Object.freeze(ctx));
+    const baseCTX = { require, __filename: this.name, __dirname: this.dir };
+    const exports = machine.runInContext(ctx, { timeout: 1000, ...run });
+    return exec(exports, baseCTX);
   };
 
   return this;
@@ -28,4 +24,10 @@ const Script = function (src, opts = {}) {
 
 Script.prepare = (src, opts) => new Script(src, opts);
 Script.execute = (src, opts) => new Script(src, opts).execute();
+Script.sandbox = Object.assign((ctx, mode = false) => {
+  if (!ctx) return Script.sandbox.EMPTY;
+  const options = { ...Script.sandbox.OPTIONS, preventEscape: mode ? 'afterEvaluate' : '' };
+  return createContext(ctx, options);
+}, require('./ctx'));
+
 module.exports = Script;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,33 +1,19 @@
 'use strict';
 
-const { WRAPPERS } = require('./default');
-const { join } = require('node:path');
-const MODULE_TYPES = Object.keys(WRAPPERS);
+const cjs = src => `(({exports, require, module, __filename, __dirname}) => {\n${src}\n});`;
+const wrap = src => `'use strict';\n` + cjs(src.replace(/['"]use strict['"];\n?/g, ''));
 
-const scriptType = name => {
-  if (!name?.includes('.')) return MODULE_TYPES[0];
-  const type = name.split('.').at(-1);
-  return MODULE_TYPES.includes(type) ? type : MODULE_TYPES[0];
-};
-
-const cjs = (closure, options) => {
+const exec = (closure, options) => {
   const exports = {};
   const module = { exports };
   closure({ exports, module, ...options });
   return module.exports;
 };
 
-const checkAccess = (module, access) => {
-  if (!access) return null;
-  const dir = join(module);
-  for (const key of Object.keys(access)) {
-    if (!dir.startsWith(key)) continue;
-    return Reflect.get(access, key);
-  }
-  return null;
+const checkAccess = (module, access, type) => {
+  if (typeof access === 'object' && access[type]) return access[type](module);
+  if (typeof access === 'function') return access(module, type);
+  return type !== 'sandbox';
 };
 
-const wrapper = (src, ext = 'js') =>
-  `'use strict';\n${WRAPPERS[ext](src.replace(/'use strict';\n?/g, ''))}`;
-
-module.exports = { scriptType, wrapper, cjs, checkAccess };
+module.exports = { exec, wrap, checkAccess };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "commonjs",
   "name": "astroctx",
   "homepage": "https://astrohelm.ru",

--- a/tests/core/examples/simple.js
+++ b/tests/core/examples/simple.js
@@ -1,9 +1,7 @@
-({
+module.exports = {
   field: 'value',
-
+  sub: (a, b) => a - b,
   add(a, b) {
     return a + b;
   },
-
-  sub: (a, b) => a - b,
-});
+};

--- a/tests/errors/examples/error.reference.js
+++ b/tests/errors/examples/error.reference.js
@@ -1,4 +1,4 @@
-async () => {
+module.exports = async () => {
   const result = unknownFunction();
   return result;
 };

--- a/tests/errors/examples/error.undef.js
+++ b/tests/errors/examples/error.undef.js
@@ -1,4 +1,4 @@
-async data => {
+module.exports = async data => {
   const result = data.unknownKey();
   return result;
 };

--- a/tests/errors/index.test.js
+++ b/tests/errors/index.test.js
@@ -4,12 +4,12 @@ const test = require('node:test');
 const assert = require('node:assert');
 const path = require('node:path');
 const Script = require('../..');
-const { read } = Script;
+const { require: read } = Script;
 const exec = Script.execute;
 
 const target = name => path.join(__dirname, 'examples', name);
 
-test('[CJS] Eval error ', async () => {
+test('[Core] Eval error ', async () => {
   try {
     exec(`module.exports = eval('100 * 2');`, { type: 'cjs' });
     assert.fail(new Error('Should throw an error.'));
@@ -18,7 +18,7 @@ test('[CJS] Eval error ', async () => {
   }
 });
 
-test('[JS] Eval error', async () => {
+test('[Core] Eval error', async () => {
   try {
     exec(`eval('100 * 2')`);
     assert.fail(new Error('Should throw an error.'));
@@ -27,7 +27,7 @@ test('[JS] Eval error', async () => {
   }
 });
 
-test('[JS] Error.notfound.js', async () => {
+test('[Core] Error.notfound.js', async () => {
   let ms;
   try {
     ms = await read(target('error.notfound.js'));
@@ -38,7 +38,7 @@ test('[JS] Error.notfound.js', async () => {
   assert.strictEqual(ms, undefined);
 });
 
-test('[JS] Error.syntax.js', async () => {
+test('[Core] Error.syntax.js', async () => {
   try {
     await read(target('error.syntax'));
     assert.fail(new Error('Should throw an error.'));
@@ -47,7 +47,7 @@ test('[JS] Error.syntax.js', async () => {
   }
 });
 
-test('[JS] Error.reference.js', async () => {
+test('[Core] Error.reference.js', async () => {
   try {
     const script = await read(target('error.reference.js'));
     await script();
@@ -58,7 +58,7 @@ test('[JS] Error.reference.js', async () => {
   }
 });
 
-test('[JS] Call undefined as a function', async () => {
+test('[Core] Call undefined as a function', async () => {
   try {
     const script = await read(target('error.undef.js'));
     await script();
@@ -68,7 +68,7 @@ test('[JS] Call undefined as a function', async () => {
   }
 });
 
-test('[JS/CJS] Error.reference.js Error.reference.cjs (line number)', async () => {
+test('[Core] Error.reference.js Error.reference.cjs (line number)', async () => {
   try {
     const script = await read(target('error.reference.js'));
     await script();
@@ -85,14 +85,13 @@ test('[JS/CJS] Error.reference.js Error.reference.cjs (line number)', async () =
     await script();
     assert.fail(new Error('Should throw an error.'));
   } catch (err) {
-    console.log(err.stack.split('\n'));
     const [, firstLine] = err.stack.split('\n');
     const [, lineNumber] = firstLine.split(':');
     assert.strictEqual(parseInt(lineNumber, 10), 4);
   }
 });
 
-test('Error.empty.js', async () => {
+test('[Core] Error.empty.js', async () => {
   try {
     await read(target('error.empty.js'));
     assert.fail(new Error('Should throw an error.'));

--- a/tests/modules/examples/module.nested.js
+++ b/tests/modules/examples/module.nested.js
@@ -1,4 +1,4 @@
-({
+module.exports = {
   name: 'module.nested',
   value: 2,
-});
+};

--- a/tests/scripts/examples/arrow.js
+++ b/tests/scripts/examples/arrow.js
@@ -1,1 +1,1 @@
-(a, b) => a + b;
+module.exports = (a, b) => a + b;

--- a/tests/scripts/examples/async.js
+++ b/tests/scripts/examples/async.js
@@ -1,4 +1,4 @@
-async (name, data) => {
+module.exports = async (name, data) => {
   if (!name) throw Error('Argument name is not defiled');
   const result = { name, data };
   return result;

--- a/tests/scripts/examples/complex.js
+++ b/tests/scripts/examples/complex.js
@@ -1,4 +1,4 @@
-({
+module.exports = {
   field: 'value',
 
   add: (a, b, callback) => {
@@ -6,4 +6,4 @@
       callback(new Error('Custom error'), a + b);
     }, 10);
   },
-});
+};

--- a/tests/scripts/examples/function.js
+++ b/tests/scripts/examples/function.js
@@ -1,4 +1,4 @@
-(function mul(a, b) {
+module.exports = function mul(a, b) {
   const result = a * b;
   return result;
-});
+};

--- a/tests/scripts/examples/local.js
+++ b/tests/scripts/examples/local.js
@@ -1,6 +1,6 @@
 const local = 'hello';
 
-async (...args) => {
+module.exports = async (...args) => {
   const result = { local, args };
   return result;
 };

--- a/tests/scripts/examples/simple
+++ b/tests/scripts/examples/simple
@@ -1,4 +1,4 @@
-({
+module.exports = {
   field: 'value',
 
   add(a, b) {
@@ -6,4 +6,4 @@
   },
 
   sub: (a, b) => a - b,
-});
+};

--- a/tests/scripts/examples/simple.js
+++ b/tests/scripts/examples/simple.js
@@ -1,4 +1,4 @@
-({
+module.exports = {
   field: 'value',
 
   add(a, b) {
@@ -6,4 +6,4 @@
   },
 
   sub: (a, b) => a - b,
-});
+};

--- a/tests/scripts/index.test.js
+++ b/tests/scripts/index.test.js
@@ -3,11 +3,11 @@
 const test = require('node:test');
 const assert = require('node:assert');
 const path = require('node:path');
-const { read, CTX } = require('../..');
+const { require: read, sandbox } = require('../..');
 
 const target = name => path.join(__dirname, 'examples', name);
 
-test('[JS] Simple.js', async () => {
+test('[Core] Simple.js', async () => {
   const ms = await read.script(target('simple.js'));
 
   assert.deepStrictEqual(Object.keys(ms), ['field', 'add', 'sub']);
@@ -16,7 +16,7 @@ test('[JS] Simple.js', async () => {
   assert.strictEqual(ms.sub(2, 3), -1);
 });
 
-test('[JS] Simple (from non extension file)', async () => {
+test('[Core] Simple (from non extension file)', async () => {
   const ms = await read.script(target('simple'));
 
   assert.deepStrictEqual(Object.keys(ms), ['field', 'add', 'sub']);
@@ -25,8 +25,8 @@ test('[JS] Simple (from non extension file)', async () => {
   assert.strictEqual(ms.sub(2, 3), -1);
 });
 
-test('[JS] Complex.js', async () => {
-  const ctx = CTX.create({ setTimeout });
+test('[Core] Complex.js', async () => {
+  const ctx = sandbox({ setTimeout });
   const options = { filename: 'CUSTOM FILE NAME', ctx };
   const ms = await read.script(target('complex.js'), options);
 
@@ -38,7 +38,7 @@ test('[JS] Complex.js', async () => {
   });
 });
 
-test('[JS] Function.js', async () => {
+test('[Core] Function.js', async () => {
   const ms = await read.script(target('function.js'));
 
   assert.strictEqual(typeof ms, 'function');
@@ -46,7 +46,7 @@ test('[JS] Function.js', async () => {
   assert.strictEqual(ms.bind(null, 3)(4), 12);
 });
 
-test('[JS] Arrow.js', async () => {
+test('[Core] Arrow.js', async () => {
   const ms = await read.script(target('arrow.js'));
 
   assert.strictEqual(typeof ms, 'function');
@@ -55,7 +55,7 @@ test('[JS] Arrow.js', async () => {
   assert.strictEqual(ms(-1, 1), 0);
 });
 
-test('[JS] Async.js', async () => {
+test('[Core] Async.js', async () => {
   const ms = await read.script(target('async.js'));
   const result = await ms('str', { field: 'value' });
 
@@ -65,7 +65,7 @@ test('[JS] Async.js', async () => {
   assert.rejects(ms('', { field: 'value' }));
 });
 
-test('[JS] Local.js', async () => {
+test('[Core] Local.js', async () => {
   const ms = await read.script(target('local.js'));
   const result = await ms('str');
 

--- a/types/context.d.ts
+++ b/types/context.d.ts
@@ -1,0 +1,39 @@
+/**
+ * @example <caption>Sandbox usage example</caption>
+ * const ctx = Astroctx.sandbox({ console, a: 1000, b: 10  });
+ * const prepared = Astroctx.prepare(`a - b`);
+ * prepared.execute(ctx); // Output: 990
+ * prepared.execute({ ...ctx, b: 7  })); // Output: 993
+ */
+export type TSandbox = {
+  /**
+   * @example <caption>This will affect on future contexts</caption>
+   * // Default config:
+   * const OPTIONS = { codeGeneration: { strings: false, wasm: false } };
+   */
+  OPTIONS: CreateContextOptions;
+
+  /**
+   * @example <caption>Empty frozen object</caption>
+   * const EMPTY = {};
+   */
+  EMPTY: Context;
+
+  /**
+   * @example <caption>Global variables such as timers and others</caption>
+   * const COMMON = { setTimeout, Event, ...other };
+   */
+  COMMON: Context;
+
+  /**
+   * @example <caption>Nodejs global variables</caption>
+   * const NODE = { global, console, process };
+   */
+  NODE: Context;
+
+  /**
+   * @example <caption>You can create custom context</caption>
+   * const ctx = Astroctx.sandbox({ console, a: 1000, b: 10  });
+   **/
+  (ctx?: Context | Object, preventEscape?: boolean): Context;
+};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,26 +1,9 @@
-import { Context, Script, ScriptOptions, BaseOptions } from 'node:vm';
-import { RunningCodeOptions, CreateContextOptions } from 'node:vm';
+import type { Context, Script, ScriptOptions, BaseOptions } from 'node:vm';
+import type { RunningCodeOptions, CreateContextOptions } from 'node:vm';
+import type { TOptions, TOptionsReader } from './options';
+import type { TSandbox } from './context';
 
-type MODULE_TYPE = 'cjs' | 'js';
 type TMap<value> = { [key: string]: value };
-
-export const COMMON_CTX: Context;
-export const MODULE_TYPES: MODULE_TYPE[];
-
-export interface TOptions extends BaseOptions {
-  dir?: string;
-  filename?: string;
-  type?: MODULE_TYPE;
-  access?: TMap<boolean | object>;
-  ctx?: Context;
-  run?: RunningCodeOptions;
-  script?: ScriptOptions;
-  npmIsolation?: boolean;
-}
-
-interface TOptionsReader extends Omit<TOptions, 'type'> {
-  prepare?: boolean;
-}
 
 type TRead = {
   (path: string, options?: TOptionsReader): Promise<Script | unknown>;
@@ -28,32 +11,23 @@ type TRead = {
   dir: (path: string, options?: TOptionsReader, deep?: boolean) => Promise<TMap<unknown | Script>>;
 };
 
-type TCtx = {
-  OPTIONS: CreateContextOptions;
-  EMPTY: Context;
-  COMMON: Context;
-  NODE: Context;
-  create: (ctx?: Context | Object, preventEscape?: boolean) => Context;
-};
-
 /**
- * Compare any Dates
- *  Create any dates compare functions or use our presets.
+ * Astroctx - VM Container for Commonjs
  * @example <caption>Basics</caption>
  * const Astroctx = require('astroctx');
  * console.log(new Astroctx(`({ field: 'value' });`).execute()); // Output: { field: 'value' }
  * console.log(Astroctx.execute(`(a, b) => a + b;`)(2 + 2)); // Output: 4
  * Astroctx.execute(`async (a, b) => a + b;`)(2 + 2).then(console.log); // Output: 4
- * @example <caption>CTX & Delay example</caption>
- * const ctx = Astroctx.CTX.create({ console, a: 1000, b: 10  });
+ * @example <caption>CTX & Delay execution example</caption>
+ * const ctx = Astroctx.sandbox({ console, a: 1000, b: 10  });
  * const prepared = Astroctx.prepare(`a - b`, { ctx });
  * prepared.execute(); // Output: 990
- * prepared.execute(Astroctx.CTX.create({ ...ctx, b: 7  })); // Output: 993
+ * prepared.execute(Astroctx.sandbox({ ...ctx, b: 7  })); // Output: 993
  * @example <caption>Read Api</caption>
- * Astroctx.read('./path/to/script.js').then(console.log); // Output: result of script execution
- * Astroctx.read('./path/to').then(console.log); // Output: { script: any }
- * Astroctx.read('./path/to', { prepare: true }).then(console.log); // Output: { script: Script {} }
- * Astroctx.read('./path/to', { deep: true }).then(console.log); // Output: { script: any, deep: { script: any } }
+ * Astroctx.require('./path/to/script.js').then(console.log); // Output: result of script execution
+ * Astroctx.require('./path/to').then(console.log); // Output: { script: any }
+ * Astroctx.require('./path/to', { prepare: true }).then(console.log); // Output: { script: Script {} }
+ * Astroctx.require('./path/to', { deep: true }).then(console.log); // Output: { script: any, deep: { script: any } }
  */
 export class Script {
   /**
@@ -64,13 +38,12 @@ export class Script {
    * @description Equivalent to __dirname
    */
   dir: string;
-  type: MODULE_TYPE;
 
-  static CTX: TCtx;
-  static read: TRead;
+  static require: TRead;
   static prepare: (src: string, options?: TOptions) => Script;
   static execute: (src: string, options?: TOptions) => unknown;
   static require: (path: string, options?: TOptionsReader) => Promise<unknown | Script>;
+  static sandbox: TSandbox;
 
   constructor(src: string, options?: TOptions): Script;
 

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -1,0 +1,17 @@
+type TAccess = (path, type?: string) => boolean | object;
+
+export interface TOptions extends BaseOptions {
+  dir?: string;
+  filename?: string;
+  npmIsolation?: boolean;
+
+  access?: { sandbox?: TAccess; internal?: TAccess } | TAccess;
+  ctx?: Context | { [key: string]: unknown };
+
+  run?: RunningCodeOptions;
+  script?: ScriptOptions;
+}
+
+export interface TOptionsReader extends Omit<TOptions, 'type'> {
+  prepare?: boolean; // By default false
+}


### PR DESCRIPTION
# v1.1.0 2023-10-01

## Major updates

- Removed astro syntax with type option, now only supports common js syntax.
- Context updates
  1. Renamed to sandbox, example: <code>Astroctx.sandbox</code>
  2. To create new contexts you should use <code>Astroctx.sandbox({ myCtxVariable: 'test' })</code>
  3. All presets still should be working properly with <code>Astroctx.sandbox[preset-key]</code>
- Reader updates
  1. Joined with require, now require works as reader, examples:
     ```js
     Astroctx.require('./my-path/to/script.js');
     Astroctx.require.script('./my-path/to/script.js');
     Astroctx.require.dir('./my-path/to');
     ```
  2. New access controll feature, see access updates
- Access updates, now this option work for both sandbox and reader, you need to provide function
  ```js
  const option = { access: pathOrModule => pathOrModule === 'fs' || pathOrModule.endsWith('.js') };
  Astroctx.execute('module.exports = require("fs")');
  Astroctx.read('./path/to/script.js');
  // But you still can controll them by each own function
  const option = {
    access: {
      internal: path => true, // Reader controll
      sandbox: module => {}, // Sandbox require controll
    },
  };
  ```
  > Sandbox function can return object or boolean value, in case of object it will be used as stub
  > content

## Minor updates

- Created new tests, new tests coverage ~85%
- NPM Isolation fix, now it should work properly

  ```js
  const script = Astroctx.execute(`module.exports = require('chalk')`, {
    access: { sandbox: () => true },
    npmIsolation: true,
    ctx: sandbox.NODE,
  }); // Output: Chalk function
  ```

- [ ] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [ ] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
