### PR TITLE
Version 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased][unreleased]
 
+## [1.4.0][] - 2023-10-26
+
+- JSDoc enhancements
+- Renamed require -> from
+- Support latest:21 nodejs version
+- Renamed Access types from [sandbox, internal] -> [realm, reader]
+
 ## [1.3.0][] - 2023-10-26
 
 - Renamed from Astroctx -> isolation

--- a/README.md
+++ b/README.md
@@ -140,34 +140,34 @@ Reader allow you to run scripts from files
   to run script later
 
   ```javascript
-  const { require: read } = require('isolation');
-  read('./path/to/script.js').then(console.log); // Output: result of script execution
-  read('./path/to').then(console.log); // Output: { script: any }
-  read('./path/to', { prepare: true }).then(console.log); // Output: { script: Script {} }
+  const Realm = require('isolation');
+  Realm.from('./path/to/script.js').then(console.log); // Output: result of script execution
+  Realm.from('./path/to').then(console.log); // Output: { script: any }
+  Realm.from('./path/to', { prepare: true }).then(console.log); // Output: { script: Script {} }
   ```
 
   By default reader works with nested directories, to disable this behavior you can do:
 
   ```js
-  const { require: read } = require('isolation');
-  read('./path/to', {}, false);
+  const Realm = require('isolation');
+  Realm.from('./path/to', {}, false);
   ```
 
 - <code>read.script</code> Allow you to read single file
 
   ```javascript
-  const { require: read } = require('isolation');
-  read.script('./path/to/script.js').then(console.log); // Output: result of script execution
-  read.script('./path/to/script.js', { prepare: true }).then(console.log); // Output: Script {}
+  const Realm = require('isolation');
+  Realm.from.script('./path/to/script.js').then(console.log); // Output: result of script execution
+  Realm.from.script('./path/to/script.js', { prepare: true }).then(console.log); // Output: Script {}
   ```
 
 - <code>read.dir</code> Allow you to read a directory
 
   ```javascript
-  const { require: read } = require('isolation');
-  read.script('./path/to').then(console.log); // Output: { script: any, deep: { script: any } }
-  read.script('./path/to', { prepare: true }).then(console.log); Output: { script: Script {} }
-  read.script('./path/to', {}, false).then(console.log); // Output: { script: any }
+  const Realm = require('isolation');
+  Realm.from.script('./path/to').then(console.log); // Output: { script: any, deep: { script: any } }
+  Realm.from.script('./path/to', { prepare: true }).then(console.log); Output: { script: Script {} }
+  Realm.from.script('./path/to', {}, false).then(console.log); // Output: { script: any }
   ```
 
 <h2>Other useful information</h2>
@@ -186,12 +186,12 @@ Reader allow you to run scripts from files
   methods
 
   ```js
-  const { execute: exec } = require('isolation');
+  const Realm = require('isolation');
   const src = `
     const fs = require('fs');
     module.exports = fs.readFile('Isolation.js');
   `;
-  const result = exec(src, {
+  const result = Realm.execute(src, {
     access: {
       sandbox: module => ({ fs: { readFile: (filename) => filename + ' Works !' } })[module];
     },

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict';
 
 module.exports = require('./lib/script');
-module.exports.require = require('./lib/reader');
+module.exports.from = require('./lib/reader');

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -22,7 +22,7 @@ read.dir = async (dir, options = {}, deep = true) => {
 
   const promises = files.reduce((acc, file) => {
     const path = join(dir, file.name);
-    if (!checkAccess(path, options.access, 'internal')) return acc;
+    if (!checkAccess(path, options.access, 'reader')) return acc;
     if (file.isDirectory() && !deep) return acc;
     return acc.push(loader(file, path)), acc;
   }, []);

--- a/lib/require.js
+++ b/lib/require.js
@@ -12,7 +12,7 @@ module.exports = (options, exec) => {
   return module => {
     const npm = !module.includes('.');
     const name = !npm ? resolve(dir, module) : module;
-    const lib = checkAccess(name, access, 'sandbox');
+    const lib = checkAccess(name, access, 'realm');
 
     if (lib instanceof Object) return lib;
     if (!lib) throw new VMError(`Access denied '${module}'`);

--- a/lib/script.js
+++ b/lib/script.js
@@ -26,6 +26,7 @@ Script.prepare = (src, opts) => new Script(src, opts);
 Script.execute = (src, opts) => new Script(src, opts).execute();
 Script.sandbox = Object.assign((ctx, mode = false) => {
   if (!ctx) return Script.sandbox.EMPTY;
+  if (isContext(ctx)) return ctx;
   const options = { ...Script.sandbox.OPTIONS, preventEscape: mode ? 'afterEvaluate' : '' };
   return createContext(ctx, options);
 }, require('./ctx'));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,7 +13,7 @@ const exec = (closure, options) => {
 const checkAccess = (module, access, type) => {
   if (typeof access === 'object' && access[type]) return access[type](module);
   if (typeof access === 'function') return access(module, type);
-  return type !== 'sandbox';
+  return type !== 'realm'; //? By default reader have full access and realm no access
 };
 
 module.exports = { exec, wrap, checkAccess };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "license": "MIT",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "commonjs",
   "name": "isolation",
   "homepage": "https://astrohelm.ru",
@@ -18,6 +18,8 @@
     "astrohelm",
     "container",
     "isolation",
+    "realm",
+    "pollution-control",
     "javascript",
     "script-loader",
     "zero-dependencies"
@@ -27,7 +29,7 @@
   "types": "types/index.d.ts",
   "packageManager": "npm@9.6.4",
   "readmeFilename": "README.md",
-  "engines": { "node": "18 || 19 || 20" },
+  "engines": { "node": ">= 18" },
   "browser": {},
   "files": ["/lib", "/types"],
 

--- a/tests/core/index.test.js
+++ b/tests/core/index.test.js
@@ -3,7 +3,7 @@ const test = require('node:test');
 const assert = require('node:assert');
 const path = require('node:path');
 const Script = require('../..');
-const { sandbox, require: read } = Script;
+const { sandbox, from: read } = Script;
 const target = name => path.join(__dirname, name);
 
 test('[CORE] Script executor', async () => {
@@ -45,7 +45,7 @@ test('[READER] Script loader', async () => {
 });
 
 test('[READER] Access control', async () => {
-  const access = { internal: path => !path.endsWith('simple.js') && !path.endsWith('.json') };
+  const access = { reader: path => !path.endsWith('simple.js') && !path.endsWith('.json') };
   const scripts = await read(target('examples'), { access });
   const { deep } = scripts;
   const { arrow } = deep;
@@ -60,7 +60,7 @@ test('[READER] Access control', async () => {
 });
 
 test('[READER] Folder loader', async () => {
-  const access = { internal: path => !path.endsWith('.json') };
+  const access = { reader: path => !path.endsWith('.json') };
   const scripts = await read(target('examples'), { access });
   const { deep, simple } = scripts;
   const { arrow } = deep;
@@ -167,7 +167,7 @@ test('[CTX] Custom', async () => {
   assert.strictEqual(ctx.global, context);
 });
 
-test('[SANDBOX] Internal', async () => {
+test('[SANDBOX] reader', async () => {
   try {
     const result = Script.execute(`const fs = require('fs');`);
     assert.strictEqual(result, undefined);

--- a/tests/errors/index.test.js
+++ b/tests/errors/index.test.js
@@ -4,14 +4,14 @@ const test = require('node:test');
 const assert = require('node:assert');
 const path = require('node:path');
 const Script = require('../..');
-const { require: read } = Script;
+const { from: read } = Script;
 const exec = Script.execute;
 
 const target = name => path.join(__dirname, 'examples', name);
 
 test('[CORE] Eval error ', async () => {
   try {
-    exec(`module.exports = eval('100 * 2');`, { type: 'cjs' });
+    exec(`module.exports = eval('100 * 2');`);
     assert.fail(new Error('Should throw an error.'));
   } catch (error) {
     assert.strictEqual(error.constructor.name, 'EvalError');

--- a/tests/modules/index.test.js
+++ b/tests/modules/index.test.js
@@ -4,7 +4,7 @@ const test = require('node:test');
 const assert = require('node:assert');
 const path = require('node:path');
 const Script = require('../..');
-const { sandbox, require: read } = Script;
+const { sandbox, from: read } = Script;
 const exec = Script.execute;
 
 const target = name => path.join(__dirname, 'examples', name);
@@ -14,7 +14,7 @@ test('[SANDBOX] For node internal module', async () => {
   context.global = context;
   const src = `module.exports = { fs: require('fs') };`;
   const ctx = sandbox(Object.freeze(context));
-  exec(src, { ctx, access: module => module === 'fs', type: 'cjs' });
+  exec(src, { ctx, access: module => module === 'fs' });
 });
 
 test('[SANDBOX] non-existent but granted', async () => {
@@ -41,7 +41,7 @@ test('[SANDBOX] Stub', async () => {
   `;
   const ms = exec(src, {
     access: {
-      sandbox: module => {
+      realm: module => {
         if (module === 'fs') {
           return {
             readFile(filename, callback) {

--- a/tests/scripts/index.test.js
+++ b/tests/scripts/index.test.js
@@ -3,7 +3,7 @@
 const test = require('node:test');
 const assert = require('node:assert');
 const path = require('node:path');
-const { require: read, sandbox } = require('../..');
+const { from: read, sandbox } = require('../..');
 
 const target = name => path.join(__dirname, 'examples', name);
 

--- a/types/context.d.ts
+++ b/types/context.d.ts
@@ -1,9 +1,8 @@
 /**
  * @example <caption>Sandbox usage example</caption>
- * const ctx = Astroctx.sandbox({ console, a: 1000, b: 10  });
- * const prepared = Astroctx.prepare(`a - b`);
- * prepared.execute(ctx); // Output: 990
- * prepared.execute({ ...ctx, b: 7  })); // Output: 993
+ * const realm = new Realm(`a - b`);
+ * realm.execute({ a: 1000, b: 10 }); // Output: 990
+ * realm.execute({ a: 1000, b: 20 }); // Output: 980
  */
 export type TSandbox = {
   /**
@@ -33,7 +32,7 @@ export type TSandbox = {
 
   /**
    * @example <caption>You can create custom context</caption>
-   * const ctx = Astroctx.sandbox({ console, a: 1000, b: 10  });
+   * const ctx = Realm.sandbox({ console, a: 1000, b: 10  });
    **/
   (ctx?: Context | Object, preventEscape?: boolean): Context;
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,22 +12,8 @@ type TRead = {
 };
 
 /**
- * Astroctx - VM Container for Commonjs
- * @example <caption>Basics</caption>
- * const Astroctx = require('astroctx');
- * console.log(new Astroctx(`({ field: 'value' });`).execute()); // Output: { field: 'value' }
- * console.log(Astroctx.execute(`(a, b) => a + b;`)(2 + 2)); // Output: 4
- * Astroctx.execute(`async (a, b) => a + b;`)(2 + 2).then(console.log); // Output: 4
- * @example <caption>CTX & Delay execution example</caption>
- * const ctx = Astroctx.sandbox({ console, a: 1000, b: 10  });
- * const prepared = Astroctx.prepare(`a - b`, { ctx });
- * prepared.execute(); // Output: 990
- * prepared.execute(Astroctx.sandbox({ ...ctx, b: 7  })); // Output: 993
- * @example <caption>Read Api</caption>
- * Astroctx.require('./path/to/script.js').then(console.log); // Output: result of script execution
- * Astroctx.require('./path/to').then(console.log); // Output: { script: any }
- * Astroctx.require('./path/to', { prepare: true }).then(console.log); // Output: { script: Script {} }
- * Astroctx.require('./path/to', { deep: true }).then(console.log); // Output: { script: any, deep: { script: any } }
+ * Isolation
+ * @description Isolate your code in custom realms / contexts
  */
 export = class Script {
   /**
@@ -39,12 +25,43 @@ export = class Script {
    */
   dir: string;
 
-  static require: TRead;
+  /**
+   * @example <caption>Read Api</caption>
+   * Realm.from('./path/to/script.js').then(console.log); // Output: result of script execution
+   * Realm.from('./path/to').then(console.log); // Output: { script: any }
+   * Realm.from('./path/to', { prepare: true }).then(console.log); // Output: { script: Script {} }
+   * Realm.from('./path/to', { deep: true }).then(console.log); // Output: { script: any, deep: { script: any } }
+   */
+  static from: TRead;
+
+  /**
+   * @example <caption>Functional initialization</caption>
+   * const Realm = require('isolation');
+   * console.log(Realm.from(`({ field: 'value' });`).execute()); // Output: { field: 'value' }
+   */
   static prepare: (src: string, options?: TOptions) => Script;
+
+  /**
+   * @example <caption>Skip init process</caption>
+   * console.log(Realm.execute(`(a, b) => a + b;`)(2 + 2)); // Output: 4
+   * Realm.execute(`async (a, b) => a + b;`)(2 + 2).then(console.log); // Output: 4
+   */
   static execute: (src: string, options?: TOptions) => unknown;
-  static require: (path: string, options?: TOptionsReader) => Promise<unknown | Script>;
+
+  /**
+   * @example <caption>Custom sandboxes</caption>
+   * const ctx = { a: 1000, b: 10 }
+   * const realm = new Realm(`a - b`, { ctx });
+   * realm.execute(); // Output: 990
+   * realm.execute({ ...ctx, b: 7  }); // Output: 993
+   */
   static sandbox: TSandbox;
 
+  /**
+   * @example <caption>Constructor initialization</caption>
+   * const Realm = require('isolation');
+   * console.log(new Realm(`({ field: 'value' });`).execute()); // Output: { field: 'value' }
+   */
   constructor(src: string, options?: TOptions): Script;
 
   /**

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -1,11 +1,22 @@
-type TAccess = (path, type?: string) => boolean | object;
+type TAccess = (path: string, type?: 'reader' | 'realm') => boolean | object;
+type TSpecific = <RES>(path: string) => RES;
 
-export interface TOptions extends BaseOptions {
+/**
+ * @example
+ * ({
+ *    dir: '/tests', //? __dirname variable, internal require startpoint
+ *    filename: 'index.js', //? __filename variable
+ *    npmIsolation: true, //? Intenal dependencies will be loaded with isolation, default is false
+ *    ctx: { console, A: 5, B: 'Hello world' }, //? Inject global variables, default {}
+ *    access: (name, type) => true, //? Controll access to Realm submodules or reader API
+ * })
+ */
+export interface TOptions {
   dir?: string;
   filename?: string;
   npmIsolation?: boolean;
 
-  access?: { sandbox?: TAccess; internal?: TAccess } | TAccess;
+  access?: { sandbox?: TSpecific<boolean | object>; internal?: TSpecific<boolean> } | TAccess;
   ctx?: Context | { [key: string]: unknown };
 
   run?: RunningCodeOptions;


### PR DESCRIPTION
## Update 2023-10-26

- JSDoc enhancements
- Renamed require -> from
- Support latest:21 nodejs version
- Renamed Access types from [sandbox, internal] -> [realm, reader]

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
- [x] update .d.ts typings
